### PR TITLE
fix(npm): correct npm registry configuration in package.json and publish-package.yml

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: "pnpm"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Restore pnpm dependencies from cache 🥡
         uses: actions/cache/restore@v4

--- a/package.json
+++ b/package.json
@@ -46,9 +46,13 @@
   ],
   "license": "MIT",
   "main": "dist/index.cjs",
-  "module": "dist/index.mjs",
+  "module": "dist/index.js",
   "name": "dev-stamp",
   "packageManager": "pnpm@10.10.0",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/antoinezanardi/dev-stamp"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated publishing workflow to explicitly use the official npm registry.
  - Modified package configuration to specify public access and set the npm registry URL.
  - Updated module entry point reference in package configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->