### PR TITLE
refactor(index): move getStampOptions to utils and update ESLint ignores

### DIFF
--- a/config/eslint/eslint.constants.ts
+++ b/config/eslint/eslint.constants.ts
@@ -55,15 +55,9 @@ const NAMING_CONVENTION_DEFAULT_CONFIG = [
 ];
 
 const ESLINT_IGNORES = [
-  ".output/*",
-  ".output/*/",
-  ".output/**/*",
-  ".output/**/*/",
-  ".output/server/chunks/runtime.mjs",
+  "dist/*",
   "node_modules/*",
   "node_modules/**/*",
-  "public/*",
-  "public/**/*",
 ];
 
 export {

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,28 +1,12 @@
-import { describe } from "vitest";
 import { Node, Window } from "happy-dom";
+import { describe } from "vitest";
 
-import { DEFAULT_STAMP_OPTIONS } from "@/index.constants";
-import { getStampOptions, stampInHtml } from "@/index";
+import { stampInHtml } from "@/index";
 
 const window = new Window({ url: "https://localhost:8080" });
 const document = window.document;
 
 describe("Dev Stamp Index", () => {
-  describe(getStampOptions, () => {
-    it("should return default options when no options are provided.", () => {
-      const result = getStampOptions({});
-
-      expect(result).toStrictEqual(DEFAULT_STAMP_OPTIONS);
-    });
-
-    it("should override default options with provided options when called.", () => {
-      const customOptions = { targetSelector: "#custom" };
-      const result = getStampOptions(customOptions);
-
-      expect(result).toStrictEqual({ ...DEFAULT_STAMP_OPTIONS, ...customOptions });
-    });
-  });
-
   describe(stampInHtml, () => {
     beforeEach(() => {
       globalThis.window = window as unknown as typeof globalThis.window;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,6 @@
 import type { StampOptions } from "@/index.types";
 import { DEFAULT_STAMP_OPTIONS } from "@/index.constants";
-
-function getStampOptions(options: Partial<StampOptions>): StampOptions {
-  return {
-    ...DEFAULT_STAMP_OPTIONS,
-    ...options,
-  };
-}
+import { getStampOptions } from "@/utils";
 
 function stampInHtml(message: string, options: Partial<StampOptions> = DEFAULT_STAMP_OPTIONS): void {
   if (typeof window === "undefined" || typeof window.document === "undefined") {
@@ -27,7 +21,6 @@ function stampInHtml(message: string, options: Partial<StampOptions> = DEFAULT_S
 }
 
 export {
-  getStampOptions,
   stampInHtml,
 };
 

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -1,0 +1,21 @@
+import { describe } from "vitest";
+
+import { DEFAULT_STAMP_OPTIONS } from "@/index.constants";
+import { getStampOptions } from "@/utils";
+
+describe("Dev Stamp Utils", () => {
+  describe(getStampOptions, () => {
+    it("should return default options when no options are provided.", () => {
+      const result = getStampOptions({});
+
+      expect(result).toStrictEqual(DEFAULT_STAMP_OPTIONS);
+    });
+
+    it("should override default options with provided options when called.", () => {
+      const customOptions = { targetSelector: "#custom" };
+      const result = getStampOptions(customOptions);
+
+      expect(result).toStrictEqual({ ...DEFAULT_STAMP_OPTIONS, ...customOptions });
+    });
+  });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,13 @@
+import { DEFAULT_STAMP_OPTIONS } from "@/index.constants";
+import type { StampOptions } from "@/index.types";
+
+function getStampOptions(options: Partial<StampOptions>): StampOptions {
+  return {
+    ...DEFAULT_STAMP_OPTIONS,
+    ...options,
+  };
+}
+
+export {
+  getStampOptions,
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a utility function for merging stamp options with default values.
- **Bug Fixes**
  - Simplified ESLint ignore patterns for improved maintainability.
- **Refactor**
  - Replaced local implementation of stamp options merging with a shared utility.
  - Removed direct export of the stamp options merging function from the main module.
- **Tests**
  - Added new tests for the utility function handling stamp options.
  - Removed outdated tests related to the previous stamp options implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->