### PR TITLE
refactor(modes): prepare codebase for various modes

### DIFF
--- a/src/index.constants.ts
+++ b/src/index.constants.ts
@@ -1,6 +1,7 @@
 import type { StampOptions } from "@/index.types";
 
 const DEFAULT_STAMP_OPTIONS: StampOptions = {
+  mode: "comment",
   targetSelector: "body",
 } as const;
 

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,6 +1,7 @@
-import { Node, Window } from "happy-dom";
+import { Window } from "happy-dom";
 import { describe } from "vitest";
 
+import * as CommentMode from "@/modes/comment/comment";
 import { stampInHtml } from "@/index";
 
 const window = new Window({ url: "https://localhost:8080" });
@@ -12,6 +13,7 @@ describe("Dev Stamp Index", () => {
       globalThis.window = window as unknown as typeof globalThis.window;
       globalThis.document = document as unknown as Document;
       window.document.body.innerHTML = "<body><h1>Title</h1><p>Text</p></body>";
+      vi.spyOn(CommentMode, "stampCommentInHtml").mockImplementation(vi.fn());
     });
 
     it("should log an error when not in a browser environment because window is undefined.", () => {
@@ -37,22 +39,11 @@ describe("Dev Stamp Index", () => {
       expect(consoleErrorSpy).toHaveBeenCalledWith("Target element not found: #nonexistent");
     });
 
-    it("should append a comment node to the target element when called.", () => {
+    it("should stamp comment in html when called.", () => {
       const message = "Hello Dark Jess' 🪄";
       stampInHtml(message);
-      const targetElement = window.document.querySelector("body");
-      const appendedNode = targetElement?.lastChild;
 
-      expect(appendedNode?.nodeType).toBe(Node.COMMENT_NODE);
-    });
-
-    it("should append a comment node with the message specified in first argument to the target element when called.", () => {
-      const message = "Hello Dark Jess' 🪄";
-      stampInHtml(message);
-      const targetElement = window.document.querySelector("body");
-      const appendedNode = targetElement?.lastChild;
-
-      expect(appendedNode?.nodeValue).toBe(message);
+      expect(CommentMode.stampCommentInHtml).toHaveBeenCalledWith(message, window.document.body);
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import type { StampOptions } from "@/index.types";
 import { DEFAULT_STAMP_OPTIONS } from "@/index.constants";
+import { stampCommentInHtml } from "@/modes/comment/comment";
 import { getStampOptions } from "@/utils/utils";
 
 function stampInHtml(message: string, options: Partial<StampOptions> = DEFAULT_STAMP_OPTIONS): void {
@@ -16,8 +17,7 @@ function stampInHtml(message: string, options: Partial<StampOptions> = DEFAULT_S
 
     return;
   }
-  const commentNode = window.document.createComment(message);
-  targetElement.appendChild(commentNode);
+  stampCommentInHtml(message, targetElement);
 }
 
 export {

--- a/src/index.types.ts
+++ b/src/index.types.ts
@@ -1,4 +1,7 @@
+type StampMode = "comment";
+
 type StampOptions = {
+  mode: StampMode;
   targetSelector: string;
 };
 

--- a/src/modes/comment/comment.spec.ts
+++ b/src/modes/comment/comment.spec.ts
@@ -1,0 +1,34 @@
+import { Node, Window } from "happy-dom";
+
+import { stampCommentInHtml } from "@/modes/comment/comment";
+
+const window = new Window({ url: "https://localhost:8080" });
+const document = window.document;
+
+describe("Comment Mode", () => {
+  describe(stampCommentInHtml, () => {
+    beforeEach(() => {
+      globalThis.window = window as unknown as typeof globalThis.window;
+      globalThis.document = document as unknown as Document;
+      window.document.body.innerHTML = "<body><h1>Title</h1><p>Text</p></body>";
+    });
+
+    it("should append a comment node to the target element when called.", () => {
+      const message = "Hello Dark Jess' 🪄";
+      const targetElement = window.document.querySelector("body");
+      stampCommentInHtml(message, targetElement as unknown as Element);
+      const appendedNode = targetElement?.lastChild;
+
+      expect(appendedNode?.nodeType).toBe(Node.COMMENT_NODE);
+    });
+
+    it("should append a comment node with the message specified in first argument to the target element when called.", () => {
+      const message = "Hello Dark Jess' 🪄";
+      const targetElement = window.document.querySelector("body");
+      stampCommentInHtml(message, targetElement as unknown as Element);
+      const appendedNode = targetElement?.lastChild;
+
+      expect(appendedNode?.nodeValue).toBe(message);
+    });
+  });
+});

--- a/src/modes/comment/comment.ts
+++ b/src/modes/comment/comment.ts
@@ -1,0 +1,6 @@
+function stampCommentInHtml(message: string, targetElement: Element): void {
+  const commentNode = window.document.createComment(message);
+  targetElement.appendChild(commentNode);
+}
+
+export { stampCommentInHtml };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new option to specify the mode for stamping, with "comment" as the default.
- **Bug Fixes**
	- Improved reliability of comment stamping by centralizing the logic into a dedicated function.
- **Tests**
	- Added and updated tests to verify comment stamping behavior using a simulated DOM environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->