### PR TITLE
feat(stamp): add meta tag injection mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ stampInHtml("💮 Made with love by [Your Name]", options);
 1. **Comment**: Injects a comment at the end of the `body` tag (by default).
 2. **Meta Tag**: Injects a meta tag in the `head` section of the HTML.
 
-You can choose the mode by setting the `mode` option in the `StampOptions`.
+You can choose the mode by setting the `mode` option in the `StampOptions` described below.
 
 ### 🦋 Options
 

--- a/README.md
+++ b/README.md
@@ -20,19 +20,19 @@
 
 ## 📜 Table of Contents
 
-- [🚀 What is Dev Stamp?](#-what-is-dev-stamp)
+- [💮 What is Dev Stamp?](#-what-is-dev-stamp)
 - [🎯 Use Cases](#-use-cases)
 - [🔥 Why You'll Love It](#-why-youll-love-it)
-- [✍️ Quick Example](#-quick-example)
+- [🚀 Quick Example](#-quick-example)
 - [📦 Installation](#-installation)
-- [🛠️ Advanced Usage](#-advanced-usage)
+- [🔧 Advanced Usage](#-advanced-usage)
 - [🧪 Robustness](#-robustness)
-- [⚖️ License](#-license)
+- [📃 License](#-license)
 - [👩‍💻 Contributing](#-contributing)
 
 ---
 
-## 🚀 What is Dev Stamp?
+## 💮 What is Dev Stamp?
 
 **Dev Stamp** is a tiny ⚡️ zero-config tool that lets you **inject custom content** (like build time, version, commit hash, or even a fun signature) right into the HTML of your project, anywhere.
 
@@ -61,7 +61,7 @@ Whether you're building apps, sites, or web widgets – Dev Stamp leaves your *d
 
 ---
 
-## ✍️ Quick Examples
+## 🚀 Quick Examples
 
 ### 💬 Inject a Comment
 
@@ -139,7 +139,7 @@ If you want to use **Dev Stamp** in a browser environment, you can include it vi
 
 ---
 
-## 🛠️ Advanced Usage
+## 🔧 Advanced Usage
 
 You can customize the stamp with various options, which can be passed as a second argument to the `stampInHtml` function.
 
@@ -206,7 +206,7 @@ You can check the mutation testing results by clicking on the badges below:
 
 ---
 
-## ⚖️ License
+## 📃 License
 
 Licensed under the [MIT License](https://opensource.org/licenses/MIT) 📄 – free as in freedom.
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@
 
 **Dev Stamp** is a tiny ⚡️ zero-config tool that lets you **inject custom content** (like build time, version, commit hash, or even a fun signature) right into the HTML of your project, anywhere.
 
+👉 Choose your injection mode: a comment in the `body` tag or a meta tag in the `head` section.
+
 Whether you're building apps, sites, or web widgets – Dev Stamp leaves your *dev mark* with style 💮.
 
 ---
@@ -121,9 +123,30 @@ const options: StampOptions = {
 stampInHtml("💮 Made with love by [Your Name]", options);
 ```
 
-|      Option      |                         Description                         | Default |
-|:----------------:|:-----------------------------------------------------------:|:-------:|
-| `targetSelector` | CSS selector to find the target element to inject the stamp | `body`  |
+### 💡 Modes of Injection
+
+**Dev Stamp** supports two modes of injection:
+
+1. **Comment**: Injects a comment at the end of the `body` tag (by default).
+2. **Meta Tag**: Injects a meta tag in the `head` section of the HTML.
+
+You can choose the mode by setting the `mode` option in the `StampOptions`.
+
+### 🦋 Options
+
+|      Field       |                     Type                     |                                             Description                                              |                           Default                           |
+|:----------------:|:--------------------------------------------:|:----------------------------------------------------------------------------------------------------:|:-----------------------------------------------------------:|
+| `targetSelector` |                   `string`                   | CSS selector to find the target element to inject the stamp. Only used if `mode` is set to `comment` |                          `"body"`                           |
+|      `mode`      |          `"comment" \| "meta-tag"`           |                           Mode of HTML injection: `comment` or `meta-tag`                            |                         `"comment"`                         |
+|    `metaTag`     |  [StampMetaTagOptions](#-meta-tag-options)   |        Options related to the `meta-tag` injection. Only used if `mode` is set to `meta-tag`         | Refer to [Meta Tag Options](#-meta-tag-options) for details |
+
+
+#### ☀️ Meta Tag Options
+
+|    Field    |   Type    |                         Description                          |    Default    |
+|:-----------:|:---------:|:------------------------------------------------------------:|:-------------:|
+|   `name`    | `string`  |             Name of the meta tag to be injected              | `"dev-stamp"` |
+| `overwrite` | `boolean` | Whether to overwrite an existing meta tag with the same name |    `true`     |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -134,14 +134,14 @@ You can choose the mode by setting the `mode` option in the `StampOptions`.
 
 ### 🦋 Options
 
-|      Field       |                     Type                     |                                             Description                                              |                           Default                           |
-|:----------------:|:--------------------------------------------:|:----------------------------------------------------------------------------------------------------:|:-----------------------------------------------------------:|
-| `targetSelector` |                   `string`                   | CSS selector to find the target element to inject the stamp. Only used if `mode` is set to `comment` |                          `"body"`                           |
-|      `mode`      |          `"comment" \| "meta-tag"`           |                           Mode of HTML injection: `comment` or `meta-tag`                            |                         `"comment"`                         |
-|    `metaTag`     |  [StampMetaTagOptions](#-meta-tag-options)   |        Options related to the `meta-tag` injection. Only used if `mode` is set to `meta-tag`         | Refer to [Meta Tag Options](#-meta-tag-options) for details |
+|      Field       |                    Type                    |                                             Description                                              |                          Default                           |
+|:----------------:|:------------------------------------------:|:----------------------------------------------------------------------------------------------------:|:----------------------------------------------------------:|
+| `targetSelector` |                  `string`                  | CSS selector to find the target element to inject the stamp. Only used if `mode` is set to `comment` |                          `"body"`                          |
+|      `mode`      |        `"comment"`<br/>`"meta-tag"`        |                           Mode of HTML injection: `comment` or `meta-tag`                            |                        `"comment"`                         |
+|    `metaTag`     |  [StampMetaTagOptions](#meta-tag-options)  |        Options related to the `meta-tag` injection. Only used if `mode` is set to `meta-tag`         | Refer to [Meta Tag Options](#meta-tag-options) for details |
 
 
-#### ☀️ Meta Tag Options
+#### Meta Tag Options
 
 |    Field    |   Type    |                         Description                          |    Default    |
 |:-----------:|:---------:|:------------------------------------------------------------:|:-------------:|

--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ Whether you're building apps, sites, or web widgets – Dev Stamp leaves your *d
 
 ---
 
-## ✍️ Quick Example
+## ✍️ Quick Examples
+
+### 💬 Inject a Comment
 
 ```ts
 import { stampInHtml } from 'dev-stamp';
@@ -82,6 +84,34 @@ stampInHtml("💮 Made with love by [Your Name]");
   </body>
 </html>
 ```
+
+For more options, please refer to the [Advanced Usage](#-advanced-usage) section.
+
+### 🪄 Inject a Meta Tag
+
+```ts
+import { stampInHtml } from 'dev-stamp';
+
+stampInHtml("🚀 Project version 1.0.0", {
+  mode: "meta-tag",
+});
+```
+
+⬇️ This adds a meta-tag at the end of the `head` tag in your HTML.
+
+```html
+<html lang="en">
+  <head>
+    <title>My Project</title>
+    <meta name="dev-stamp" content="🚀 Project version 1.0.0">
+  </head>
+  <body>
+    <h1>Hello, World!</h1>
+  </body>
+</html>
+```
+
+For more options, please refer to the [Advanced Usage](#-advanced-usage) section.
 
 ---
 
@@ -137,7 +167,7 @@ You can choose the mode by setting the `mode` option in the `StampOptions`.
 |      Field       |                    Type                    |                                             Description                                              |                          Default                           |
 |:----------------:|:------------------------------------------:|:----------------------------------------------------------------------------------------------------:|:----------------------------------------------------------:|
 | `targetSelector` |                  `string`                  | CSS selector to find the target element to inject the stamp. Only used if `mode` is set to `comment` |                          `"body"`                          |
-|      `mode`      |        `"comment"`<br/>`"meta-tag"`        |                           Mode of HTML injection: `comment` or `meta-tag`                            |                        `"comment"`                         |
+|      `mode`      |        `"comment"`<br/>`"meta-tag"`        |                                        Mode of HTML injection                                        |                        `"comment"`                         |
 |    `metaTag`     |  [StampMetaTagOptions](#meta-tag-options)  |        Options related to the `meta-tag` injection. Only used if `mode` is set to `meta-tag`         | Refer to [Meta Tag Options](#meta-tag-options) for details |
 
 

--- a/config/eslint/flat-configs/eslint.unit-tests-config.ts
+++ b/config/eslint/flat-configs/eslint.unit-tests-config.ts
@@ -1,8 +1,8 @@
 import Vitest from "@vitest/eslint-plugin";
 import type { Linter } from "eslint";
 
-const ESLINT_TESTS_CONFIG = {
-  name: "tests",
+const ESLINT_UNIT_TESTS_CONFIG = {
+  name: "unit-tests",
   files: ["src/**/*.spec.ts"],
   plugins: { vitest: Vitest },
   rules: {
@@ -92,4 +92,4 @@ const ESLINT_TESTS_CONFIG = {
   },
 } satisfies Linter.Config;
 
-export { ESLINT_TESTS_CONFIG };
+export { ESLINT_UNIT_TESTS_CONFIG };

--- a/config/eslint/flat-configs/eslint.unit-tests-setup-config.ts
+++ b/config/eslint/flat-configs/eslint.unit-tests-setup-config.ts
@@ -1,0 +1,11 @@
+import type { Linter } from "eslint";
+
+const ESLINT_UNIT_TESTS_SETUP_CONFIG = {
+  name: "unit-tests-setup",
+  files: ["tests/unit/setup.ts"],
+  rules: {
+    "@typescript-eslint/no-unsafe-type-assertion": "off",
+  },
+} satisfies Linter.Config;
+
+export { ESLINT_UNIT_TESTS_SETUP_CONFIG };

--- a/config/vitest/vitest.global-unit-tests-config.ts
+++ b/config/vitest/vitest.global-unit-tests-config.ts
@@ -37,6 +37,7 @@ export default defineConfig({
     clearMocks: true,
     mockReset: true,
     restoreMocks: true,
+    setupFiles: ["./tests/unit/setup.ts"],
   },
   plugins: [tsconfigPaths()],
 });

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -9,7 +9,8 @@ import { ESLINT_TYPESCRIPT_DECLARATION_CONFIG } from "./config/eslint/flat-confi
 import { ESLINT_STYLISTIC_CONFIG } from "./config/eslint/flat-configs/eslint.stylistic-config";
 import { ESLINT_CONFIG_FILES_CONFIG } from "./config/eslint/flat-configs/eslint.config-files-config";
 import { ESLINT_CLASSES_CONFIG } from "./config/eslint/flat-configs/eslint.classes-config";
-import { ESLINT_TESTS_CONFIG } from "./config/eslint/flat-configs/eslint.tests-config";
+import { ESLINT_UNIT_TESTS_CONFIG } from "./config/eslint/flat-configs/eslint.unit-tests-config";
+import { ESLINT_UNIT_TESTS_SETUP_CONFIG } from "./config/eslint/flat-configs/eslint.unit-tests-setup-config";
 
 export default [
   {
@@ -24,5 +25,6 @@ export default [
   ESLINT_STYLISTIC_CONFIG,
   ESLINT_CONFIG_FILES_CONFIG,
   ESLINT_CLASSES_CONFIG,
-  ESLINT_TESTS_CONFIG,
+  ESLINT_UNIT_TESTS_CONFIG,
+  ESLINT_UNIT_TESTS_SETUP_CONFIG,
 ] satisfies Linter.Config[];

--- a/src/index.constants.ts
+++ b/src/index.constants.ts
@@ -1,8 +1,14 @@
-import type { StampOptions } from "@/index.types";
+import type { StampMetaTagOptions, StampOptions } from "@/index.types";
+
+const DEFAULT_META_TAG_OPTIONS: StampMetaTagOptions = {
+  name: "dev-stamp",
+  overwrite: true,
+} as const;
 
 const DEFAULT_STAMP_OPTIONS: StampOptions = {
   mode: "comment",
   targetSelector: "body",
+  metaTag: DEFAULT_META_TAG_OPTIONS,
 } as const;
 
 export { DEFAULT_STAMP_OPTIONS };

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -10,10 +10,6 @@ import * as Utils from "@/utils/utils";
 describe("Dev Stamp Index", () => {
   describe(stampInHtml, () => {
     beforeEach(() => {
-      globalThis.window = window as unknown as typeof globalThis.window;
-      globalThis.document = document as unknown as Document;
-      window.document.body.innerHTML = "<body><h1>Title</h1><p>Text</p></body>";
-
       vi.spyOn(CommentMode, "stampCommentInHtml").mockImplementation(vi.fn());
       vi.spyOn(MetaTagMode, "stampMetaTagInHtml").mockImplementation(vi.fn());
       vi.spyOn(Utils, "getStampOptions").mockReturnValue(DEFAULT_STAMP_OPTIONS);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import type { StampMode, StampOptions } from "@/index.types";
+import type { StampMode, StampOptions, StampMetaTagOptions } from "@/index.types";
 import { DEFAULT_STAMP_OPTIONS } from "@/index.constants";
 import { stampCommentInHtml } from "@/modes/comment/comment";
 import { stampMetaTagInHtml } from "@/modes/meta-tag/meta-tag";
@@ -23,4 +23,7 @@ export {
   stampInHtml,
 };
 
-export type { StampOptions };
+export type {
+  StampOptions,
+  StampMetaTagOptions,
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,23 +1,22 @@
-import type { StampOptions } from "@/index.types";
+import type { StampMode, StampOptions } from "@/index.types";
 import { DEFAULT_STAMP_OPTIONS } from "@/index.constants";
 import { stampCommentInHtml } from "@/modes/comment/comment";
-import { getStampOptions } from "@/utils/utils";
+import { stampMetaTagInHtml } from "@/modes/meta-tag/meta-tag";
+import { getStampOptions, validateBrowserEnvironment } from "@/utils/utils";
 
 function stampInHtml(message: string, options: Partial<StampOptions> = DEFAULT_STAMP_OPTIONS): void {
-  if (typeof window === "undefined" || typeof window.document === "undefined") {
-    console.error("This function can only be run in a browser environment.");
-
-    return;
-  }
   const mergedOptions = getStampOptions(options);
-  const { targetSelector } = mergedOptions;
-  const targetElement = window.document.querySelector(targetSelector);
-  if (!targetElement) {
-    console.error(`Target element not found: ${targetSelector}`);
+  const stampMethods: Record<StampMode, () => void> = {
+    "comment": () => stampCommentInHtml(message, mergedOptions),
+    "meta-tag": () => stampMetaTagInHtml(message, mergedOptions),
+  };
 
-    return;
+  try {
+    validateBrowserEnvironment();
+    stampMethods[mergedOptions.mode]();
+  } catch (error) {
+    console.error(error);
   }
-  stampCommentInHtml(message, targetElement);
 }
 
 export {

--- a/src/index.types.ts
+++ b/src/index.types.ts
@@ -1,8 +1,23 @@
-type StampMode = "comment";
+type StampMode = "comment" | "meta-tag";
+
+type StampMetaTagOptions = {
+  name: string;
+  overwrite: boolean;
+};
 
 type StampOptions = {
   mode: StampMode;
   targetSelector: string;
+  metaTag: StampMetaTagOptions;
 };
 
-export type { StampOptions };
+type PartialStampOptions = Omit<Partial<StampOptions>, "metaTag"> & {
+  metaTag?: Partial<StampMetaTagOptions>;
+};
+
+export type {
+  StampMode,
+  StampMetaTagOptions,
+  StampOptions,
+  PartialStampOptions,
+};

--- a/src/modes/comment/comment.spec.ts
+++ b/src/modes/comment/comment.spec.ts
@@ -1,10 +1,12 @@
+import { Node } from "happy-dom";
+
 import { DEFAULT_STAMP_OPTIONS } from "@/index.constants";
 import * as Utils from "@/utils/utils";
 import { stampCommentInHtml } from "@/modes/comment/comment";
 
 describe("Comment Mode", () => {
   beforeEach(() => {
-    vi.spyOn(Utils, "getTargetElement").mockImplementation(() => document.createElement("body"));
+    vi.spyOn(Utils, "getTargetElement").mockReturnValue(document.createElement("body"));
   });
 
   describe(stampCommentInHtml, () => {
@@ -24,6 +26,28 @@ describe("Comment Mode", () => {
       stampCommentInHtml(message, DEFAULT_STAMP_OPTIONS);
 
       expect(appendChildSpy).toHaveBeenCalledWith(commentNode);
+    });
+
+    it("should append a comment node to the target element when called.", () => {
+      const message = "Hello Dark Jess' 🪄";
+      const targetElement = window.document.querySelector("body");
+      const appendChildSpy = vi.spyOn(targetElement as Element, "appendChild");
+      vi.spyOn(Utils, "getTargetElement").mockReturnValue(targetElement as Element);
+      stampCommentInHtml(message, DEFAULT_STAMP_OPTIONS);
+      const appendedNode = appendChildSpy.mock.calls[0][0] as Comment;
+
+      expect(appendedNode.nodeType).toBe(Node.COMMENT_NODE);
+    });
+
+    it("should append a comment node with the message specified in first argument to the target element when called.", () => {
+      const message = "Hello Dark Jess' 🪄";
+      const targetElement = window.document.querySelector("body");
+      const appendChildSpy = vi.spyOn(targetElement as Element, "appendChild");
+      vi.spyOn(Utils, "getTargetElement").mockReturnValue(targetElement as Element);
+      stampCommentInHtml(message, DEFAULT_STAMP_OPTIONS);
+      const appendedNode = appendChildSpy.mock.calls[0][0] as Comment;
+
+      expect(appendedNode.textContent).toBe(message);
     });
   });
 });

--- a/src/modes/comment/comment.spec.ts
+++ b/src/modes/comment/comment.spec.ts
@@ -1,34 +1,29 @@
-import { Node, Window } from "happy-dom";
-
+import { DEFAULT_STAMP_OPTIONS } from "@/index.constants";
+import * as Utils from "@/utils/utils";
 import { stampCommentInHtml } from "@/modes/comment/comment";
 
-const window = new Window({ url: "https://localhost:8080" });
-const document = window.document;
-
 describe("Comment Mode", () => {
+  beforeEach(() => {
+    vi.spyOn(Utils, "getTargetElement").mockImplementation(() => document.createElement("body"));
+  });
+
   describe(stampCommentInHtml, () => {
-    beforeEach(() => {
-      globalThis.window = window as unknown as typeof globalThis.window;
-      globalThis.document = document as unknown as Document;
-      window.document.body.innerHTML = "<body><h1>Title</h1><p>Text</p></body>";
+    it("should get the target element when called.", () => {
+      const message = "Hello Dark Jess' 🪄";
+      stampCommentInHtml(message, DEFAULT_STAMP_OPTIONS);
+
+      expect(Utils.getTargetElement).toHaveBeenCalledWith(DEFAULT_STAMP_OPTIONS.targetSelector);
     });
 
-    it("should append a comment node to the target element when called.", () => {
+    it("should create comment node with the message when called.", () => {
       const message = "Hello Dark Jess' 🪄";
       const targetElement = window.document.querySelector("body");
-      stampCommentInHtml(message, targetElement as unknown as Element);
-      const appendedNode = targetElement?.lastChild;
+      const commentNode = window.document.createComment(message);
+      const appendChildSpy = vi.spyOn(targetElement as Element, "appendChild");
+      vi.spyOn(Utils, "getTargetElement").mockReturnValue(targetElement as Element);
+      stampCommentInHtml(message, DEFAULT_STAMP_OPTIONS);
 
-      expect(appendedNode?.nodeType).toBe(Node.COMMENT_NODE);
-    });
-
-    it("should append a comment node with the message specified in first argument to the target element when called.", () => {
-      const message = "Hello Dark Jess' 🪄";
-      const targetElement = window.document.querySelector("body");
-      stampCommentInHtml(message, targetElement as unknown as Element);
-      const appendedNode = targetElement?.lastChild;
-
-      expect(appendedNode?.nodeValue).toBe(message);
+      expect(appendChildSpy).toHaveBeenCalledWith(commentNode);
     });
   });
 });

--- a/src/modes/comment/comment.ts
+++ b/src/modes/comment/comment.ts
@@ -1,4 +1,9 @@
-function stampCommentInHtml(message: string, targetElement: Element): void {
+import type { StampOptions } from "@/index.types";
+import { getTargetElement } from "@/utils/utils";
+
+function stampCommentInHtml(message: string, options: StampOptions): void {
+  const { targetSelector } = options;
+  const targetElement = getTargetElement(targetSelector);
   const commentNode = window.document.createComment(message);
   targetElement.appendChild(commentNode);
 }

--- a/src/modes/meta-tag/meta-tag.spec.ts
+++ b/src/modes/meta-tag/meta-tag.spec.ts
@@ -37,6 +37,41 @@ describe("Meta Tag Mode", () => {
       expect(appendChildSpy).toHaveBeenCalledExactlyOnceWith(appendedMetaTag);
     });
 
+    it("should create a new meta tag when called.", () => {
+      const message = "Hello Dark Jess' 🪄";
+      const { head } = window.document;
+      const appendChildSpy = vi.spyOn(head, "appendChild");
+      stampMetaTagInHtml(message, DEFAULT_STAMP_OPTIONS);
+      const appendedElement = appendChildSpy.mock.calls[0][0] as HTMLMetaElement;
+
+      expect(appendedElement.tagName).toBe("META");
+    });
+
+    it("should create a new meta tag with the personalized name when set in options.", () => {
+      const message = "Hello Dark Jess' 🪄";
+      const { head } = window.document;
+      const appendChildSpy = vi.spyOn(head, "appendChild");
+      const customName = "custom-name";
+      const customOptions = {
+        ...DEFAULT_STAMP_OPTIONS,
+        metaTag: { ...DEFAULT_STAMP_OPTIONS.metaTag, name: customName },
+      };
+      stampMetaTagInHtml(message, customOptions);
+      const appendedElement = appendChildSpy.mock.calls[0][0] as HTMLMetaElement;
+
+      expect(appendedElement.getAttribute("name")).toBe(customName);
+    });
+
+    it("should create a new meta tag with the message as content when called.", () => {
+      const message = "Hello Dark Jess' 🪄";
+      const { head } = window.document;
+      const appendChildSpy = vi.spyOn(head, "appendChild");
+      stampMetaTagInHtml(message, DEFAULT_STAMP_OPTIONS);
+      const appendedElement = appendChildSpy.mock.calls[0][0] as HTMLMetaElement;
+
+      expect(appendedElement.getAttribute("content")).toBe(message);
+    });
+
     it("should call stampOnExistingMetaTag when there is an existing meta tag.", () => {
       const message = "Hello Dark Jess' 🪄";
       const { head } = window.document;

--- a/src/modes/meta-tag/meta-tag.spec.ts
+++ b/src/modes/meta-tag/meta-tag.spec.ts
@@ -1,0 +1,51 @@
+import { DEFAULT_STAMP_OPTIONS } from "@/index.constants";
+import { stampMetaTagInHtml, stampOnExistingMetaTag } from "@/modes/meta-tag/meta-tag";
+
+describe("Meta Tag Mode", () => {
+  describe(stampOnExistingMetaTag, () => {
+    it("should set the content attribute of the existing meta tag to the message when overwrite is true.", () => {
+      const message = "Hello Dark Jess' 🪄";
+      const existingMetaTag = document.createElement("meta");
+      const options = { name: "description", overwrite: true };
+      const setAttributeSpy = vi.spyOn(existingMetaTag, "setAttribute");
+      stampOnExistingMetaTag(message, existingMetaTag, options);
+
+      expect(setAttributeSpy).toHaveBeenCalledExactlyOnceWith("content", message);
+    });
+
+    it("should log an error when overwrite is false.", () => {
+      const message = "Hello Dark Jess' 🪄";
+      const existingMetaTag = document.createElement("meta");
+      const options = { name: "description", overwrite: false };
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(vi.fn());
+      stampOnExistingMetaTag(message, existingMetaTag, options);
+
+      expect(consoleErrorSpy).toHaveBeenCalledExactlyOnceWith(`Meta tag with name "${options.name}" already exists. Use "overwrite" option to replace it.`);
+    });
+  });
+
+  describe(stampMetaTagInHtml, () => {
+    it("should create a new meta tag with the message when there is no existing meta tag.", () => {
+      const message = "Hello Dark Jess' 🪄";
+      const { head } = window.document;
+      const appendChildSpy = vi.spyOn(head, "appendChild");
+      const appendedMetaTag = window.document.createElement("meta");
+      appendedMetaTag.setAttribute("name", DEFAULT_STAMP_OPTIONS.metaTag.name);
+      appendedMetaTag.setAttribute("content", message);
+      stampMetaTagInHtml(message, DEFAULT_STAMP_OPTIONS);
+
+      expect(appendChildSpy).toHaveBeenCalledExactlyOnceWith(appendedMetaTag);
+    });
+
+    it("should call stampOnExistingMetaTag when there is an existing meta tag.", () => {
+      const message = "Hello Dark Jess' 🪄";
+      const { head } = window.document;
+      const existingMetaTag = window.document.createElement("meta");
+      existingMetaTag.setAttribute("name", DEFAULT_STAMP_OPTIONS.metaTag.name);
+      head.appendChild(existingMetaTag);
+      stampMetaTagInHtml(message, DEFAULT_STAMP_OPTIONS);
+
+      expect(existingMetaTag.getAttribute("content")).toBe(message);
+    });
+  });
+});

--- a/src/modes/meta-tag/meta-tag.ts
+++ b/src/modes/meta-tag/meta-tag.ts
@@ -1,0 +1,31 @@
+import type { StampMetaTagOptions, StampOptions } from "@/index.types";
+
+function stampOnExistingMetaTag(message: string, existingMetaTag: Element, options: StampMetaTagOptions): void {
+  const { overwrite: doesOverride } = options;
+  if (!doesOverride) {
+    console.error(`Meta tag with name "${options.name}" already exists. Use "overwrite" option to replace it.`);
+
+    return;
+  }
+  existingMetaTag.setAttribute("content", message);
+}
+
+function stampMetaTagInHtml(message: string, options: StampOptions): void {
+  const { head } = window.document;
+  const { name } = options.metaTag;
+  const existingMetaTag = head.querySelector(`meta[name="${name}"]`);
+  if (existingMetaTag) {
+    stampOnExistingMetaTag(message, existingMetaTag, options.metaTag);
+
+    return;
+  }
+  const metaTag = window.document.createElement("meta");
+  metaTag.setAttribute("name", name);
+  metaTag.setAttribute("content", message);
+  head.appendChild(metaTag);
+}
+
+export {
+  stampOnExistingMetaTag,
+  stampMetaTagInHtml,
+};

--- a/src/utils/utils.spec.ts
+++ b/src/utils/utils.spec.ts
@@ -1,21 +1,68 @@
 import { describe } from "vitest";
 
+import type { PartialStampOptions, StampOptions } from "@/index.types";
 import { DEFAULT_STAMP_OPTIONS } from "@/index.constants";
-import { getStampOptions } from "@/utils/utils";
+import { getStampOptions, getTargetElement, validateBrowserEnvironment } from "@/utils/utils";
 
 describe("Dev Stamp Utils", () => {
+  describe(validateBrowserEnvironment, () => {
+    it("should throw an error when not in a browser environment because window is undefined.", () => {
+      globalThis.window = undefined as unknown as typeof globalThis.window;
+
+      expect(() => validateBrowserEnvironment()).toThrow("This function can only be run in a browser environment.");
+    });
+
+    it("should throw an error when not in a browser environment because document is undefined.", () => {
+      globalThis.window = {} as unknown as typeof globalThis.window;
+
+      expect(() => validateBrowserEnvironment()).toThrow("This function can only be run in a browser environment.");
+    });
+
+    it("should not throw an error when in a browser environment.", () => {
+      globalThis.window = window as unknown as typeof globalThis.window;
+
+      expect(() => validateBrowserEnvironment()).not.toThrow();
+    });
+  });
+
+  describe(getTargetElement, () => {
+    it("should throw an error when the target element is not found.", () => {
+      const targetSelector = "#nonexistent";
+
+      expect(() => getTargetElement(targetSelector)).toThrow(`Target element not found: ${targetSelector}`);
+    });
+
+    it("should return the target element when it is found.", () => {
+      const targetSelector = "h1";
+      const targetElement = getTargetElement(targetSelector);
+
+      expect(targetElement.nodeName).toBe("H1");
+    });
+  });
+
   describe(getStampOptions, () => {
     it("should return default options when no options are provided.", () => {
       const result = getStampOptions({});
 
-      expect(result).toStrictEqual(DEFAULT_STAMP_OPTIONS);
+      expect(result).toStrictEqual<StampOptions>(DEFAULT_STAMP_OPTIONS);
     });
 
     it("should override default options with provided options when called.", () => {
-      const customOptions = { targetSelector: "#custom" };
+      const customOptions: PartialStampOptions = {
+        targetSelector: "#custom",
+        metaTag: {},
+      };
       const result = getStampOptions(customOptions);
+      const expectedOptions: StampOptions = {
+        ...DEFAULT_STAMP_OPTIONS,
+        ...customOptions,
+        metaTag: {
+          ...DEFAULT_STAMP_OPTIONS.metaTag,
+          ...customOptions.metaTag,
+        },
+      };
 
-      expect(result).toStrictEqual({ ...DEFAULT_STAMP_OPTIONS, ...customOptions });
+      expect(result).toStrictEqual<StampOptions>(expectedOptions);
     });
   });
 });

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,13 +1,33 @@
 import { DEFAULT_STAMP_OPTIONS } from "@/index.constants";
-import type { StampOptions } from "@/index.types";
+import type { PartialStampOptions, StampOptions } from "@/index.types";
 
-function getStampOptions(options: Partial<StampOptions>): StampOptions {
+function validateBrowserEnvironment(): void {
+  if (typeof window === "undefined" || typeof window.document === "undefined") {
+    throw new Error("This function can only be run in a browser environment.");
+  }
+}
+
+function getTargetElement(targetSelector: string): Element {
+  const targetElement = window.document.querySelector(targetSelector);
+  if (!targetElement) {
+    throw new Error(`Target element not found: ${targetSelector}`);
+  }
+  return targetElement;
+}
+
+function getStampOptions(options: PartialStampOptions): StampOptions {
   return {
     ...DEFAULT_STAMP_OPTIONS,
     ...options,
+    metaTag: {
+      ...DEFAULT_STAMP_OPTIONS.metaTag,
+      ...options.metaTag,
+    },
   };
 }
 
 export {
+  validateBrowserEnvironment,
+  getTargetElement,
   getStampOptions,
 };

--- a/tests/stryker/incremental/incremental.json
+++ b/tests/stryker/incremental/incremental.json
@@ -5,80 +5,81 @@
       "mutants": [
         {
           "id": "1",
-          "mutatorName": "ConditionalExpression",
-          "replacement": "true",
-          "statusReason": "src/index.ts(20,3): error TS18047: 'targetElement' is possibly 'null'.\n",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "src/index.ts(9,9): error TS2739: Type '{}' is missing the following properties from type 'Record<StampMode, () => void>': comment, \"meta-tag\"\n",
           "status": "CompileError",
           "static": false,
           "coveredBy": [
             "0",
             "1",
             "2",
-            "3",
-            "4"
+            "3"
           ],
           "location": {
             "end": {
-              "column": 78,
-              "line": 6
+              "column": 4,
+              "line": 12
             },
             "start": {
-              "column": 7,
-              "line": 6
-            }
-          }
-        },
-        {
-          "id": "3",
-          "mutatorName": "LogicalOperator",
-          "replacement": "typeof window === \"undefined\" && typeof window.document === \"undefined\"",
-          "statusReason": "src/index.ts(6,54): error TS2339: Property 'document' does not exist on type 'never'.\n",
-          "status": "CompileError",
-          "static": false,
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4"
-          ],
-          "location": {
-            "end": {
-              "column": 78,
-              "line": 6
-            },
-            "start": {
-              "column": 7,
-              "line": 6
+              "column": 55,
+              "line": 9
             }
           }
         },
         {
           "id": "2",
-          "mutatorName": "ConditionalExpression",
-          "replacement": "false",
-          "statusReason": "Cannot read properties of undefined (reading 'document')",
+          "mutatorName": "ArrowFunction",
+          "replacement": "() => undefined",
+          "statusReason": "expected \"stampCommentInHtml\" to be called once with arguments: [ 'Hello Dark Jess\\' 🪄', …(1) ]\u001b[90m\n\nNumber of calls: \u001b[1m0\u001b[22m\n\u001b[39m",
           "status": "Killed",
           "static": false,
-          "testsCompleted": 1,
+          "testsCompleted": 2,
           "killedBy": [
-            "0"
+            "1"
           ],
           "coveredBy": [
             "0",
             "1",
             "2",
-            "3",
-            "4"
+            "3"
           ],
           "location": {
             "end": {
-              "column": 78,
-              "line": 6
+              "column": 64,
+              "line": 10
             },
             "start": {
-              "column": 7,
-              "line": 6
+              "column": 16,
+              "line": 10
+            }
+          }
+        },
+        {
+          "id": "3",
+          "mutatorName": "ArrowFunction",
+          "replacement": "() => undefined",
+          "statusReason": "expected \"stampMetaTagInHtml\" to be called once with arguments: [ 'Hello Dark Jess\\' 🪄', …(1) ]\u001b[90m\n\nNumber of calls: \u001b[1m0\u001b[22m\n\u001b[39m",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 3,
+          "killedBy": [
+            "2"
+          ],
+          "coveredBy": [
+            "0",
+            "1",
+            "2",
+            "3"
+          ],
+          "location": {
+            "end": {
+              "column": 65,
+              "line": 11
+            },
+            "start": {
+              "column": 17,
+              "line": 11
             }
           }
         },
@@ -86,7 +87,7 @@
           "id": "0",
           "mutatorName": "BlockStatement",
           "replacement": "{}",
-          "statusReason": "expected \"error\" to be called with arguments: [ Array(1) ]\u001b[90m\n\nNumber of calls: \u001b[1m0\u001b[22m\n\u001b[39m",
+          "statusReason": "expected \"validateBrowserEnvironment\" to be called once with arguments: []\u001b[90m\n\nNumber of calls: \u001b[1m0\u001b[22m\n\u001b[39m",
           "status": "Killed",
           "static": false,
           "testsCompleted": 1,
@@ -97,180 +98,24 @@
             "0",
             "1",
             "2",
-            "3",
-            "4"
+            "3"
           ],
           "location": {
             "end": {
               "column": 2,
-              "line": 21
+              "line": 20
             },
             "start": {
               "column": 101,
-              "line": 5
-            }
-          }
-        },
-        {
-          "id": "5",
-          "mutatorName": "EqualityOperator",
-          "replacement": "typeof window !== \"undefined\"",
-          "statusReason": "src/index.ts(6,54): error TS2339: Property 'document' does not exist on type 'never'.\nsrc/index.ts(13,32): error TS2339: Property 'document' does not exist on type 'never'.\nsrc/index.ts(19,30): error TS2339: Property 'document' does not exist on type 'never'.\n",
-          "status": "CompileError",
-          "static": false,
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4"
-          ],
-          "location": {
-            "end": {
-              "column": 36,
-              "line": 6
-            },
-            "start": {
-              "column": 7,
-              "line": 6
-            }
-          }
-        },
-        {
-          "id": "6",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "src/index.ts(6,7): error TS2367: This comparison appears to be unintentional because the types '\"string\" | \"number\" | \"bigint\" | \"boolean\" | \"symbol\" | \"undefined\" | \"object\" | \"function\"' and '\"\"' have no overlap.\nsrc/index.ts(6,45): error TS2339: Property 'document' does not exist on type 'never'.\nsrc/index.ts(13,32): error TS2339: Property 'document' does not exist on type 'never'.\nsrc/index.ts(19,30): error TS2339: Property 'document' does not exist on type 'never'.\n",
-          "status": "CompileError",
-          "static": false,
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4"
-          ],
-          "location": {
-            "end": {
-              "column": 36,
-              "line": 6
-            },
-            "start": {
-              "column": 25,
-              "line": 6
-            }
-          }
-        },
-        {
-          "id": "7",
-          "mutatorName": "ConditionalExpression",
-          "replacement": "false",
-          "statusReason": "Cannot read properties of undefined (reading 'querySelector')",
-          "status": "Killed",
-          "static": false,
-          "testsCompleted": 1,
-          "killedBy": [
-            "1"
-          ],
-          "coveredBy": [
-            "1",
-            "2",
-            "3",
-            "4"
-          ],
-          "location": {
-            "end": {
-              "column": 78,
-              "line": 6
-            },
-            "start": {
-              "column": 40,
-              "line": 6
+              "line": 7
             }
           }
         },
         {
           "id": "4",
-          "mutatorName": "ConditionalExpression",
-          "replacement": "false",
-          "statusReason": "Cannot read properties of undefined (reading 'document')",
-          "status": "Killed",
-          "static": false,
-          "testsCompleted": 1,
-          "killedBy": [
-            "0"
-          ],
-          "coveredBy": [
-            "0",
-            "1",
-            "2",
-            "3",
-            "4"
-          ],
-          "location": {
-            "end": {
-              "column": 36,
-              "line": 6
-            },
-            "start": {
-              "column": 7,
-              "line": 6
-            }
-          }
-        },
-        {
-          "id": "8",
-          "mutatorName": "EqualityOperator",
-          "replacement": "typeof window.document !== \"undefined\"",
-          "statusReason": "src/index.ts(13,41): error TS2339: Property 'querySelector' does not exist on type 'never'.\nsrc/index.ts(19,39): error TS2339: Property 'createComment' does not exist on type 'never'.\n",
-          "status": "CompileError",
-          "static": false,
-          "coveredBy": [
-            "1",
-            "2",
-            "3",
-            "4"
-          ],
-          "location": {
-            "end": {
-              "column": 78,
-              "line": 6
-            },
-            "start": {
-              "column": 40,
-              "line": 6
-            }
-          }
-        },
-        {
-          "id": "9",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "src/index.ts(6,40): error TS2367: This comparison appears to be unintentional because the types '\"string\" | \"number\" | \"bigint\" | \"boolean\" | \"symbol\" | \"undefined\" | \"object\" | \"function\"' and '\"\"' have no overlap.\nsrc/index.ts(13,41): error TS2339: Property 'querySelector' does not exist on type 'never'.\nsrc/index.ts(19,39): error TS2339: Property 'createComment' does not exist on type 'never'.\n",
-          "status": "CompileError",
-          "static": false,
-          "coveredBy": [
-            "1",
-            "2",
-            "3",
-            "4"
-          ],
-          "location": {
-            "end": {
-              "column": 78,
-              "line": 6
-            },
-            "start": {
-              "column": 67,
-              "line": 6
-            }
-          }
-        },
-        {
-          "id": "10",
           "mutatorName": "BlockStatement",
           "replacement": "{}",
-          "statusReason": "Cannot read properties of undefined (reading 'document')",
+          "statusReason": "expected \"validateBrowserEnvironment\" to be called once with arguments: []\u001b[90m\n\nNumber of calls: \u001b[1m0\u001b[22m\n\u001b[39m",
           "status": "Killed",
           "static": false,
           "testsCompleted": 1,
@@ -279,179 +124,66 @@
           ],
           "coveredBy": [
             "0",
-            "1"
+            "1",
+            "2",
+            "3"
           ],
           "location": {
             "end": {
               "column": 4,
-              "line": 10
+              "line": 17
             },
             "start": {
-              "column": 80,
-              "line": 6
+              "column": 7,
+              "line": 14
             }
           }
         },
         {
-          "id": "11",
-          "mutatorName": "StringLiteral",
-          "replacement": "\"\"",
-          "statusReason": "expected \"error\" to be called with arguments: [ Array(1) ]\u001b[90m\n\nReceived: \n\n\u001b[1m  1st error call:\n\n\u001b[22m\u001b[2m  [\u001b[22m\n\u001b[32m-   \"This function can only be run in a browser environment.\",\u001b[90m\n\u001b[31m+   \"\",\u001b[90m\n\u001b[2m  ]\u001b[22m\n\u001b[39m\u001b[90m\n\nNumber of calls: \u001b[1m1\u001b[22m\n\u001b[39m",
+          "id": "5",
+          "mutatorName": "BlockStatement",
+          "replacement": "{}",
+          "statusReason": "expected \"error\" to be called with arguments: [ Error: Test error ]\u001b[90m\n\nNumber of calls: \u001b[1m0\u001b[22m\n\u001b[39m",
           "status": "Killed",
           "static": false,
           "testsCompleted": 1,
           "killedBy": [
-            "0"
+            "3"
           ],
           "coveredBy": [
-            "0",
-            "1"
-          ],
-          "location": {
-            "end": {
-              "column": 76,
-              "line": 7
-            },
-            "start": {
-              "column": 19,
-              "line": 7
-            }
-          }
-        },
-        {
-          "id": "12",
-          "mutatorName": "BooleanLiteral",
-          "replacement": "targetElement",
-          "statusReason": "src/index.ts(20,3): error TS18047: 'targetElement' is possibly 'null'.\n",
-          "status": "CompileError",
-          "static": false,
-          "coveredBy": [
-            "2",
-            "3",
-            "4"
-          ],
-          "location": {
-            "end": {
-              "column": 21,
-              "line": 14
-            },
-            "start": {
-              "column": 7,
-              "line": 14
-            }
-          }
-        },
-        {
-          "id": "13",
-          "mutatorName": "ConditionalExpression",
-          "replacement": "true",
-          "statusReason": "src/index.ts(20,3): error TS18047: 'targetElement' is possibly 'null'.\n",
-          "status": "CompileError",
-          "static": false,
-          "coveredBy": [
-            "2",
-            "3",
-            "4"
-          ],
-          "location": {
-            "end": {
-              "column": 21,
-              "line": 14
-            },
-            "start": {
-              "column": 7,
-              "line": 14
-            }
-          }
-        },
-        {
-          "id": "15",
-          "mutatorName": "BlockStatement",
-          "replacement": "{}",
-          "statusReason": "src/index.ts(16,3): error TS18047: 'targetElement' is possibly 'null'.\n",
-          "status": "CompileError",
-          "static": false,
-          "coveredBy": [
-            "2"
+            "3"
           ],
           "location": {
             "end": {
               "column": 4,
-              "line": 18
-            },
-            "start": {
-              "column": 23,
-              "line": 14
-            }
-          }
-        },
-        {
-          "id": "14",
-          "mutatorName": "ConditionalExpression",
-          "replacement": "false",
-          "statusReason": "src/index.ts(20,3): error TS18047: 'targetElement' is possibly 'null'.\n",
-          "status": "CompileError",
-          "static": false,
-          "coveredBy": [
-            "2",
-            "3",
-            "4"
-          ],
-          "location": {
-            "end": {
-              "column": 21,
-              "line": 14
-            },
-            "start": {
-              "column": 7,
-              "line": 14
-            }
-          }
-        },
-        {
-          "id": "16",
-          "mutatorName": "StringLiteral",
-          "replacement": "``",
-          "statusReason": "expected \"error\" to be called with arguments: [ Array(1) ]\u001b[90m\n\nReceived: \n\n\u001b[1m  1st error call:\n\n\u001b[22m\u001b[2m  [\u001b[22m\n\u001b[32m-   \"Target element not found: #nonexistent\",\u001b[90m\n\u001b[31m+   \"\",\u001b[90m\n\u001b[2m  ]\u001b[22m\n\u001b[39m\u001b[90m\n\nNumber of calls: \u001b[1m1\u001b[22m\n\u001b[39m",
-          "status": "Killed",
-          "static": false,
-          "testsCompleted": 1,
-          "killedBy": [
-            "2"
-          ],
-          "coveredBy": [
-            "2"
-          ],
-          "location": {
-            "end": {
-              "column": 64,
-              "line": 15
+              "line": 19
             },
             "start": {
               "column": 19,
-              "line": 15
+              "line": 17
             }
           }
         }
       ],
-      "source": "import type { StampOptions } from \"@/index.types\";\nimport { DEFAULT_STAMP_OPTIONS } from \"@/index.constants\";\nimport { getStampOptions } from \"@/utils/utils\";\n\nfunction stampInHtml(message: string, options: Partial<StampOptions> = DEFAULT_STAMP_OPTIONS): void {\n  if (typeof window === \"undefined\" || typeof window.document === \"undefined\") {\n    console.error(\"This function can only be run in a browser environment.\");\n\n    return;\n  }\n  const mergedOptions = getStampOptions(options);\n  const { targetSelector } = mergedOptions;\n  const targetElement = window.document.querySelector(targetSelector);\n  if (!targetElement) {\n    console.error(`Target element not found: ${targetSelector}`);\n\n    return;\n  }\n  const commentNode = window.document.createComment(message);\n  targetElement.appendChild(commentNode);\n}\n\nexport {\n  stampInHtml,\n};\n\nexport type { StampOptions };"
+      "source": "import type { StampMode, StampOptions } from \"@/index.types\";\nimport { DEFAULT_STAMP_OPTIONS } from \"@/index.constants\";\nimport { stampCommentInHtml } from \"@/modes/comment/comment\";\nimport { stampMetaTagInHtml } from \"@/modes/meta-tag/meta-tag\";\nimport { getStampOptions, validateBrowserEnvironment } from \"@/utils/utils\";\n\nfunction stampInHtml(message: string, options: Partial<StampOptions> = DEFAULT_STAMP_OPTIONS): void {\n  const mergedOptions = getStampOptions(options);\n  const stampMethods: Record<StampMode, () => void> = {\n    \"comment\": () => stampCommentInHtml(message, mergedOptions),\n    \"meta-tag\": () => stampMetaTagInHtml(message, mergedOptions),\n  };\n\n  try {\n    validateBrowserEnvironment();\n    stampMethods[mergedOptions.mode]();\n  } catch (error) {\n    console.error(error);\n  }\n}\n\nexport {\n  stampInHtml,\n};\n\nexport type { StampOptions };"
     },
-    "src/utils/utils.ts": {
+    "src/modes/comment/comment.ts": {
       "language": "typescript",
       "mutants": [
         {
-          "id": "17",
+          "id": "6",
           "mutatorName": "BlockStatement",
           "replacement": "{}",
-          "statusReason": "src/utils/utils.ts(4,59): error TS2355: A function whose declared type is neither 'undefined', 'void', nor 'any' must return a value.\n",
-          "status": "CompileError",
+          "statusReason": "expected \"getTargetElement\" to be called with arguments: [ 'body' ]\u001b[90m\n\nNumber of calls: \u001b[1m0\u001b[22m\n\u001b[39m",
+          "status": "Killed",
           "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "15"
+          ],
           "coveredBy": [
-            "2",
-            "3",
-            "4",
-            "5",
-            "6"
+            "15",
+            "16"
           ],
           "location": {
             "end": {
@@ -459,38 +191,908 @@
               "line": 9
             },
             "start": {
-              "column": 72,
+              "column": 75,
               "line": 4
+            }
+          }
+        }
+      ],
+      "source": "import type { StampOptions } from \"@/index.types\";\nimport { getTargetElement } from \"@/utils/utils\";\n\nfunction stampCommentInHtml(message: string, options: StampOptions): void {\n  const { targetSelector } = options;\n  const targetElement = getTargetElement(targetSelector);\n  const commentNode = window.document.createComment(message);\n  targetElement.appendChild(commentNode);\n}\n\nexport { stampCommentInHtml };"
+    },
+    "src/modes/meta-tag/meta-tag.ts": {
+      "language": "typescript",
+      "mutants": [
+        {
+          "id": "7",
+          "mutatorName": "BlockStatement",
+          "replacement": "{}",
+          "statusReason": "expected \"setAttribute\" to be called once with arguments: [ 'content', 'Hello Dark Jess\\' 🪄' ]\u001b[90m\n\nNumber of calls: \u001b[1m0\u001b[22m\n\u001b[39m",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "11"
+          ],
+          "coveredBy": [
+            "11",
+            "12",
+            "14"
+          ],
+          "location": {
+            "end": {
+              "column": 2,
+              "line": 11
+            },
+            "start": {
+              "column": 112,
+              "line": 3
+            }
+          }
+        },
+        {
+          "id": "8",
+          "mutatorName": "BooleanLiteral",
+          "replacement": "doesOverride",
+          "statusReason": "expected \"setAttribute\" to be called once with arguments: [ 'content', 'Hello Dark Jess\\' 🪄' ]\u001b[90m\n\nNumber of calls: \u001b[1m0\u001b[22m\n\u001b[39m",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "11"
+          ],
+          "coveredBy": [
+            "11",
+            "12",
+            "14"
+          ],
+          "location": {
+            "end": {
+              "column": 20,
+              "line": 5
+            },
+            "start": {
+              "column": 7,
+              "line": 5
+            }
+          }
+        },
+        {
+          "id": "9",
+          "mutatorName": "ConditionalExpression",
+          "replacement": "true",
+          "statusReason": "expected \"setAttribute\" to be called once with arguments: [ 'content', 'Hello Dark Jess\\' 🪄' ]\u001b[90m\n\nNumber of calls: \u001b[1m0\u001b[22m\n\u001b[39m",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "11"
+          ],
+          "coveredBy": [
+            "11",
+            "12",
+            "14"
+          ],
+          "location": {
+            "end": {
+              "column": 20,
+              "line": 5
+            },
+            "start": {
+              "column": 7,
+              "line": 5
+            }
+          }
+        },
+        {
+          "id": "10",
+          "mutatorName": "ConditionalExpression",
+          "replacement": "false",
+          "statusReason": "expected \"error\" to be called once with arguments: [ Array(1) ]\u001b[90m\n\nNumber of calls: \u001b[1m0\u001b[22m\n\u001b[39m",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 2,
+          "killedBy": [
+            "12"
+          ],
+          "coveredBy": [
+            "11",
+            "12",
+            "14"
+          ],
+          "location": {
+            "end": {
+              "column": 20,
+              "line": 5
+            },
+            "start": {
+              "column": 7,
+              "line": 5
+            }
+          }
+        },
+        {
+          "id": "12",
+          "mutatorName": "StringLiteral",
+          "replacement": "``",
+          "statusReason": "expected \"error\" to be called once with arguments: [ Array(1) ]\u001b[90m\n\nReceived: \n\n\u001b[1m  1st error call:\n\n\u001b[22m\u001b[2m  [\u001b[22m\n\u001b[32m-   \"Meta tag with name \\\"description\\\" already exists. Use \\\"overwrite\\\" option to replace it.\",\u001b[90m\n\u001b[31m+   \"\",\u001b[90m\n\u001b[2m  ]\u001b[22m\n\u001b[39m\u001b[90m\n\nNumber of calls: \u001b[1m1\u001b[22m\n\u001b[39m",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "12"
+          ],
+          "coveredBy": [
+            "12"
+          ],
+          "location": {
+            "end": {
+              "column": 111,
+              "line": 6
+            },
+            "start": {
+              "column": 19,
+              "line": 6
+            }
+          }
+        },
+        {
+          "id": "11",
+          "mutatorName": "BlockStatement",
+          "replacement": "{}",
+          "statusReason": "expected \"error\" to be called once with arguments: [ Array(1) ]\u001b[90m\n\nNumber of calls: \u001b[1m0\u001b[22m\n\u001b[39m",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "12"
+          ],
+          "coveredBy": [
+            "12"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 9
+            },
+            "start": {
+              "column": 22,
+              "line": 5
+            }
+          }
+        },
+        {
+          "id": "13",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "Uncaught InvalidCharacterError: Failed to execute 'setAttribute' on 'Element': '' is not a valid attribute name.",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "11"
+          ],
+          "coveredBy": [
+            "11",
+            "14"
+          ],
+          "location": {
+            "end": {
+              "column": 41,
+              "line": 10
+            },
+            "start": {
+              "column": 32,
+              "line": 10
+            }
+          }
+        },
+        {
+          "id": "16",
+          "mutatorName": "ConditionalExpression",
+          "replacement": "true",
+          "statusReason": "src/modes/meta-tag/meta-tag.ts(18,37): error TS2345: Argument of type 'Element | null' is not assignable to parameter of type 'Element'.\n  Type 'null' is not assignable to type 'Element'.\n",
+          "status": "CompileError",
+          "static": false,
+          "coveredBy": [
+            "13",
+            "14"
+          ],
+          "location": {
+            "end": {
+              "column": 22,
+              "line": 17
+            },
+            "start": {
+              "column": 7,
+              "line": 17
+            }
+          }
+        },
+        {
+          "id": "17",
+          "mutatorName": "ConditionalExpression",
+          "replacement": "false",
+          "statusReason": "src/modes/meta-tag/meta-tag.ts(18,37): error TS2345: Argument of type 'Element | null' is not assignable to parameter of type 'Element'.\n  Type 'null' is not assignable to type 'Element'.\n",
+          "status": "CompileError",
+          "static": false,
+          "coveredBy": [
+            "13",
+            "14"
+          ],
+          "location": {
+            "end": {
+              "column": 22,
+              "line": 17
+            },
+            "start": {
+              "column": 7,
+              "line": 17
+            }
+          }
+        },
+        {
+          "id": "15",
+          "mutatorName": "StringLiteral",
+          "replacement": "``",
+          "statusReason": "Failed to execute 'querySelector' on 'HTMLHeadElement': The provided selector is empty.",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "13"
+          ],
+          "coveredBy": [
+            "13",
+            "14"
+          ],
+          "location": {
+            "end": {
+              "column": 68,
+              "line": 16
+            },
+            "start": {
+              "column": 46,
+              "line": 16
+            }
+          }
+        },
+        {
+          "id": "14",
+          "mutatorName": "BlockStatement",
+          "replacement": "{}",
+          "statusReason": "expected \"appendChild\" to be called once with arguments: [ HTMLMetaElement{ …(46) } ]\u001b[90m\n\nNumber of calls: \u001b[1m0\u001b[22m\n\u001b[39m",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "13"
+          ],
+          "coveredBy": [
+            "13",
+            "14"
+          ],
+          "location": {
+            "end": {
+              "column": 2,
+              "line": 26
+            },
+            "start": {
+              "column": 75,
+              "line": 13
             }
           }
         },
         {
           "id": "18",
-          "mutatorName": "ObjectLiteral",
+          "mutatorName": "BlockStatement",
           "replacement": "{}",
-          "statusReason": "src/utils/utils.ts(5,3): error TS2741: Property 'targetSelector' is missing in type '{}' but required in type 'StampOptions'.\n",
-          "status": "CompileError",
+          "statusReason": "expected null to be 'Hello Dark Jess\\' 🪄' // Object.is equality",
+          "status": "Killed",
           "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "14"
+          ],
           "coveredBy": [
-            "2",
-            "3",
+            "14"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 21
+            },
+            "start": {
+              "column": 24,
+              "line": 17
+            }
+          }
+        },
+        {
+          "id": "20",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "Uncaught InvalidCharacterError: Failed to execute 'setAttribute' on 'Element': '' is not a valid attribute name.",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "13"
+          ],
+          "coveredBy": [
+            "13"
+          ],
+          "location": {
+            "end": {
+              "column": 30,
+              "line": 23
+            },
+            "start": {
+              "column": 24,
+              "line": 23
+            }
+          }
+        },
+        {
+          "id": "19",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "Failed to execute 'createElementNS' on 'Document': The qualified name provided is empty.",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "13"
+          ],
+          "coveredBy": [
+            "13"
+          ],
+          "location": {
+            "end": {
+              "column": 55,
+              "line": 22
+            },
+            "start": {
+              "column": 49,
+              "line": 22
+            }
+          }
+        },
+        {
+          "id": "21",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "Uncaught InvalidCharacterError: Failed to execute 'setAttribute' on 'Element': '' is not a valid attribute name.",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "13"
+          ],
+          "coveredBy": [
+            "13"
+          ],
+          "location": {
+            "end": {
+              "column": 33,
+              "line": 24
+            },
+            "start": {
+              "column": 24,
+              "line": 24
+            }
+          }
+        }
+      ],
+      "source": "import type { StampMetaTagOptions, StampOptions } from \"@/index.types\";\n\nfunction stampOnExistingMetaTag(message: string, existingMetaTag: Element, options: StampMetaTagOptions): void {\n  const { overwrite: doesOverride } = options;\n  if (!doesOverride) {\n    console.error(`Meta tag with name \"${options.name}\" already exists. Use \"overwrite\" option to replace it.`);\n\n    return;\n  }\n  existingMetaTag.setAttribute(\"content\", message);\n}\n\nfunction stampMetaTagInHtml(message: string, options: StampOptions): void {\n  const { head } = window.document;\n  const { name } = options.metaTag;\n  const existingMetaTag = head.querySelector(`meta[name=\"${name}\"]`);\n  if (existingMetaTag) {\n    stampOnExistingMetaTag(message, existingMetaTag, options.metaTag);\n\n    return;\n  }\n  const metaTag = window.document.createElement(\"meta\");\n  metaTag.setAttribute(\"name\", name);\n  metaTag.setAttribute(\"content\", message);\n  head.appendChild(metaTag);\n}\n\nexport {\n  stampOnExistingMetaTag,\n  stampMetaTagInHtml,\n};"
+    },
+    "src/utils/utils.ts": {
+      "language": "typescript",
+      "mutants": [
+        {
+          "id": "22",
+          "mutatorName": "BlockStatement",
+          "replacement": "{}",
+          "statusReason": "expected [Function] to throw an error",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "4"
+          ],
+          "coveredBy": [
             "4",
             "5",
             "6"
           ],
           "location": {
             "end": {
-              "column": 4,
+              "column": 2,
               "line": 8
             },
             "start": {
-              "column": 10,
+              "column": 45,
+              "line": 4
+            }
+          }
+        },
+        {
+          "id": "23",
+          "mutatorName": "ConditionalExpression",
+          "replacement": "true",
+          "statusReason": "expected [Function] to not throw an error but 'Error: This function can only be run …' was thrown",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 3,
+          "killedBy": [
+            "6"
+          ],
+          "coveredBy": [
+            "4",
+            "5",
+            "6"
+          ],
+          "location": {
+            "end": {
+              "column": 78,
               "line": 5
+            },
+            "start": {
+              "column": 7,
+              "line": 5
+            }
+          }
+        },
+        {
+          "id": "25",
+          "mutatorName": "LogicalOperator",
+          "replacement": "typeof window === \"undefined\" && typeof window.document === \"undefined\"",
+          "statusReason": "src/utils/utils.ts(5,54): error TS2339: Property 'document' does not exist on type 'never'.\n",
+          "status": "CompileError",
+          "static": false,
+          "coveredBy": [
+            "4",
+            "5",
+            "6"
+          ],
+          "location": {
+            "end": {
+              "column": 78,
+              "line": 5
+            },
+            "start": {
+              "column": 7,
+              "line": 5
+            }
+          }
+        },
+        {
+          "id": "24",
+          "mutatorName": "ConditionalExpression",
+          "replacement": "false",
+          "statusReason": "expected [Function] to throw an error",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "4"
+          ],
+          "coveredBy": [
+            "4",
+            "5",
+            "6"
+          ],
+          "location": {
+            "end": {
+              "column": 78,
+              "line": 5
+            },
+            "start": {
+              "column": 7,
+              "line": 5
+            }
+          }
+        },
+        {
+          "id": "27",
+          "mutatorName": "EqualityOperator",
+          "replacement": "typeof window !== \"undefined\"",
+          "statusReason": "src/utils/utils.ts(5,54): error TS2339: Property 'document' does not exist on type 'never'.\n",
+          "status": "CompileError",
+          "static": false,
+          "coveredBy": [
+            "4",
+            "5",
+            "6"
+          ],
+          "location": {
+            "end": {
+              "column": 36,
+              "line": 5
+            },
+            "start": {
+              "column": 7,
+              "line": 5
+            }
+          }
+        },
+        {
+          "id": "26",
+          "mutatorName": "ConditionalExpression",
+          "replacement": "false",
+          "statusReason": "expected [Function] to throw error including 'This function can only be run in a br…' but got 'Cannot read properties of undefined (…'",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "4"
+          ],
+          "coveredBy": [
+            "4",
+            "5",
+            "6"
+          ],
+          "location": {
+            "end": {
+              "column": 36,
+              "line": 5
+            },
+            "start": {
+              "column": 7,
+              "line": 5
+            }
+          }
+        },
+        {
+          "id": "28",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "src/utils/utils.ts(5,7): error TS2367: This comparison appears to be unintentional because the types '\"string\" | \"number\" | \"bigint\" | \"boolean\" | \"symbol\" | \"undefined\" | \"object\" | \"function\"' and '\"\"' have no overlap.\nsrc/utils/utils.ts(5,45): error TS2339: Property 'document' does not exist on type 'never'.\n",
+          "status": "CompileError",
+          "static": false,
+          "coveredBy": [
+            "4",
+            "5",
+            "6"
+          ],
+          "location": {
+            "end": {
+              "column": 36,
+              "line": 5
+            },
+            "start": {
+              "column": 25,
+              "line": 5
+            }
+          }
+        },
+        {
+          "id": "29",
+          "mutatorName": "ConditionalExpression",
+          "replacement": "false",
+          "statusReason": "expected [Function] to throw an error",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "5"
+          ],
+          "coveredBy": [
+            "5",
+            "6"
+          ],
+          "location": {
+            "end": {
+              "column": 78,
+              "line": 5
+            },
+            "start": {
+              "column": 40,
+              "line": 5
+            }
+          }
+        },
+        {
+          "id": "31",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "src/utils/utils.ts(5,40): error TS2367: This comparison appears to be unintentional because the types '\"string\" | \"number\" | \"bigint\" | \"boolean\" | \"symbol\" | \"undefined\" | \"object\" | \"function\"' and '\"\"' have no overlap.\n",
+          "status": "CompileError",
+          "static": false,
+          "coveredBy": [
+            "5",
+            "6"
+          ],
+          "location": {
+            "end": {
+              "column": 78,
+              "line": 5
+            },
+            "start": {
+              "column": 67,
+              "line": 5
+            }
+          }
+        },
+        {
+          "id": "30",
+          "mutatorName": "EqualityOperator",
+          "replacement": "typeof window.document !== \"undefined\"",
+          "statusReason": "expected [Function] to throw an error",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "5"
+          ],
+          "coveredBy": [
+            "5",
+            "6"
+          ],
+          "location": {
+            "end": {
+              "column": 78,
+              "line": 5
+            },
+            "start": {
+              "column": 40,
+              "line": 5
+            }
+          }
+        },
+        {
+          "id": "34",
+          "mutatorName": "BlockStatement",
+          "replacement": "{}",
+          "statusReason": "src/utils/utils.ts(10,52): error TS2355: A function whose declared type is neither 'undefined', 'void', nor 'any' must return a value.\n",
+          "status": "CompileError",
+          "static": false,
+          "coveredBy": [
+            "7",
+            "8"
+          ],
+          "location": {
+            "end": {
+              "column": 2,
+              "line": 16
+            },
+            "start": {
+              "column": 60,
+              "line": 10
+            }
+          }
+        },
+        {
+          "id": "35",
+          "mutatorName": "BooleanLiteral",
+          "replacement": "targetElement",
+          "statusReason": "src/utils/utils.ts(15,3): error TS2322: Type 'null' is not assignable to type 'Element'.\n",
+          "status": "CompileError",
+          "static": false,
+          "coveredBy": [
+            "7",
+            "8"
+          ],
+          "location": {
+            "end": {
+              "column": 21,
+              "line": 12
+            },
+            "start": {
+              "column": 7,
+              "line": 12
+            }
+          }
+        },
+        {
+          "id": "32",
+          "mutatorName": "BlockStatement",
+          "replacement": "{}",
+          "statusReason": "expected [Function] to throw an error",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "4"
+          ],
+          "coveredBy": [
+            "4",
+            "5"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 7
+            },
+            "start": {
+              "column": 80,
+              "line": 5
+            }
+          }
+        },
+        {
+          "id": "33",
+          "mutatorName": "StringLiteral",
+          "replacement": "\"\"",
+          "statusReason": "expected [Function] to throw error including 'This function can only be run in a br…' but got ''",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "4"
+          ],
+          "coveredBy": [
+            "4",
+            "5"
+          ],
+          "location": {
+            "end": {
+              "column": 78,
+              "line": 6
+            },
+            "start": {
+              "column": 21,
+              "line": 6
+            }
+          }
+        },
+        {
+          "id": "36",
+          "mutatorName": "ConditionalExpression",
+          "replacement": "true",
+          "statusReason": "src/utils/utils.ts(15,3): error TS2322: Type 'Element | null' is not assignable to type 'Element'.\n  Type 'null' is not assignable to type 'Element'.\n",
+          "status": "CompileError",
+          "static": false,
+          "coveredBy": [
+            "7",
+            "8"
+          ],
+          "location": {
+            "end": {
+              "column": 21,
+              "line": 12
+            },
+            "start": {
+              "column": 7,
+              "line": 12
+            }
+          }
+        },
+        {
+          "id": "37",
+          "mutatorName": "ConditionalExpression",
+          "replacement": "false",
+          "statusReason": "src/utils/utils.ts(15,3): error TS2322: Type 'Element | null' is not assignable to type 'Element'.\n  Type 'null' is not assignable to type 'Element'.\n",
+          "status": "CompileError",
+          "static": false,
+          "coveredBy": [
+            "7",
+            "8"
+          ],
+          "location": {
+            "end": {
+              "column": 21,
+              "line": 12
+            },
+            "start": {
+              "column": 7,
+              "line": 12
+            }
+          }
+        },
+        {
+          "id": "38",
+          "mutatorName": "BlockStatement",
+          "replacement": "{}",
+          "statusReason": "src/utils/utils.ts(13,3): error TS2322: Type 'Element | null' is not assignable to type 'Element'.\n  Type 'null' is not assignable to type 'Element'.\n",
+          "status": "CompileError",
+          "static": false,
+          "coveredBy": [
+            "7"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 14
+            },
+            "start": {
+              "column": 23,
+              "line": 12
+            }
+          }
+        },
+        {
+          "id": "39",
+          "mutatorName": "StringLiteral",
+          "replacement": "``",
+          "statusReason": "expected [Function] to throw error including 'Target element not found: #nonexistent' but got ''",
+          "status": "Killed",
+          "static": false,
+          "testsCompleted": 1,
+          "killedBy": [
+            "7"
+          ],
+          "coveredBy": [
+            "7"
+          ],
+          "location": {
+            "end": {
+              "column": 66,
+              "line": 13
+            },
+            "start": {
+              "column": 21,
+              "line": 13
+            }
+          }
+        },
+        {
+          "id": "40",
+          "mutatorName": "BlockStatement",
+          "replacement": "{}",
+          "statusReason": "src/utils/utils.ts(18,57): error TS2355: A function whose declared type is neither 'undefined', 'void', nor 'any' must return a value.\n",
+          "status": "CompileError",
+          "static": false,
+          "coveredBy": [
+            "9",
+            "10"
+          ],
+          "location": {
+            "end": {
+              "column": 2,
+              "line": 27
+            },
+            "start": {
+              "column": 70,
+              "line": 18
+            }
+          }
+        },
+        {
+          "id": "41",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "src/utils/utils.ts(19,3): error TS2739: Type '{}' is missing the following properties from type 'StampOptions': mode, targetSelector, metaTag\n",
+          "status": "CompileError",
+          "static": false,
+          "coveredBy": [
+            "9",
+            "10"
+          ],
+          "location": {
+            "end": {
+              "column": 4,
+              "line": 26
+            },
+            "start": {
+              "column": 10,
+              "line": 19
+            }
+          }
+        },
+        {
+          "id": "42",
+          "mutatorName": "ObjectLiteral",
+          "replacement": "{}",
+          "statusReason": "src/utils/utils.ts(22,5): error TS2739: Type '{}' is missing the following properties from type 'StampMetaTagOptions': name, overwrite\n",
+          "status": "CompileError",
+          "static": false,
+          "coveredBy": [
+            "9",
+            "10"
+          ],
+          "location": {
+            "end": {
+              "column": 6,
+              "line": 25
+            },
+            "start": {
+              "column": 14,
+              "line": 22
             }
           }
         }
       ],
-      "source": "import { DEFAULT_STAMP_OPTIONS } from \"@/index.constants\";\nimport type { StampOptions } from \"@/index.types\";\n\nfunction getStampOptions(options: Partial<StampOptions>): StampOptions {\n  return {\n    ...DEFAULT_STAMP_OPTIONS,\n    ...options,\n  };\n}\n\nexport {\n  getStampOptions,\n};"
+      "source": "import { DEFAULT_STAMP_OPTIONS } from \"@/index.constants\";\nimport type { PartialStampOptions, StampOptions } from \"@/index.types\";\n\nfunction validateBrowserEnvironment(): void {\n  if (typeof window === \"undefined\" || typeof window.document === \"undefined\") {\n    throw new Error(\"This function can only be run in a browser environment.\");\n  }\n}\n\nfunction getTargetElement(targetSelector: string): Element {\n  const targetElement = window.document.querySelector(targetSelector);\n  if (!targetElement) {\n    throw new Error(`Target element not found: ${targetSelector}`);\n  }\n  return targetElement;\n}\n\nfunction getStampOptions(options: PartialStampOptions): StampOptions {\n  return {\n    ...DEFAULT_STAMP_OPTIONS,\n    ...options,\n    metaTag: {\n      ...DEFAULT_STAMP_OPTIONS.metaTag,\n      ...options.metaTag,\n    },\n  };\n}\n\nexport {\n  validateBrowserEnvironment,\n  getTargetElement,\n  getStampOptions,\n};"
     }
   },
   "schemaVersion": "1.0",
@@ -504,42 +1106,92 @@
       "tests": [
         {
           "id": "0",
-          "name": "Dev Stamp Index stampInHtml should log an error when not in a browser environment because window is undefined."
+          "name": "Dev Stamp Index stampInHtml should validate the browser environment when called."
         },
         {
           "id": "1",
-          "name": "Dev Stamp Index stampInHtml should log an error when not in a browser environment because document is undefined."
+          "name": "Dev Stamp Index stampInHtml should call the comment mode when the mode is comment."
         },
         {
           "id": "2",
-          "name": "Dev Stamp Index stampInHtml should log an error when the target element is not found."
+          "name": "Dev Stamp Index stampInHtml should call the meta tag mode when the mode is meta-tag."
         },
         {
           "id": "3",
-          "name": "Dev Stamp Index stampInHtml should append a comment node to the target element when called."
-        },
-        {
-          "id": "4",
-          "name": "Dev Stamp Index stampInHtml should append a comment node with the message specified in first argument to the target element when called."
+          "name": "Dev Stamp Index stampInHtml should log an error when one of the stamp methods throws an error."
         }
       ],
-      "source": "import { Node, Window } from \"happy-dom\";\nimport { describe } from \"vitest\";\n\nimport { stampInHtml } from \"@/index\";\n\nconst window = new Window({ url: \"https://localhost:8080\" });\nconst document = window.document;\n\ndescribe(\"Dev Stamp Index\", () => {\n  describe(stampInHtml, () => {\n    beforeEach(() => {\n      globalThis.window = window as unknown as typeof globalThis.window;\n      globalThis.document = document as unknown as Document;\n      window.document.body.innerHTML = \"<body><h1>Title</h1><p>Text</p></body>\";\n    });\n\n    it(\"should log an error when not in a browser environment because window is undefined.\", () => {\n      globalThis.window = undefined as unknown as typeof globalThis.window;\n      const consoleErrorSpy = vi.spyOn(console, \"error\").mockImplementation(vi.fn());\n      stampInHtml(\"Test message\");\n\n      expect(consoleErrorSpy).toHaveBeenCalledWith(\"This function can only be run in a browser environment.\");\n    });\n\n    it(\"should log an error when not in a browser environment because document is undefined.\", () => {\n      globalThis.window = {} as unknown as typeof globalThis.window;\n      const consoleErrorSpy = vi.spyOn(console, \"error\").mockImplementation(vi.fn());\n      stampInHtml(\"Test message\");\n\n      expect(consoleErrorSpy).toHaveBeenCalledWith(\"This function can only be run in a browser environment.\");\n    });\n\n    it(\"should log an error when the target element is not found.\", () => {\n      const consoleErrorSpy = vi.spyOn(console, \"error\").mockImplementation(vi.fn());\n      stampInHtml(\"Test message\", { targetSelector: \"#nonexistent\" });\n\n      expect(consoleErrorSpy).toHaveBeenCalledWith(\"Target element not found: #nonexistent\");\n    });\n\n    it(\"should append a comment node to the target element when called.\", () => {\n      const message = \"Hello Dark Jess' 🪄\";\n      stampInHtml(message);\n      const targetElement = window.document.querySelector(\"body\");\n      const appendedNode = targetElement?.lastChild;\n\n      expect(appendedNode?.nodeType).toBe(Node.COMMENT_NODE);\n    });\n\n    it(\"should append a comment node with the message specified in first argument to the target element when called.\", () => {\n      const message = \"Hello Dark Jess' 🪄\";\n      stampInHtml(message);\n      const targetElement = window.document.querySelector(\"body\");\n      const appendedNode = targetElement?.lastChild;\n\n      expect(appendedNode?.nodeValue).toBe(message);\n    });\n  });\n});"
+      "source": "import { describe } from \"vitest\";\n\nimport type { StampOptions } from \"@/index\";\nimport { stampInHtml } from \"@/index\";\nimport { DEFAULT_STAMP_OPTIONS } from \"@/index.constants\";\nimport * as CommentMode from \"@/modes/comment/comment\";\nimport * as MetaTagMode from \"@/modes/meta-tag/meta-tag\";\nimport * as Utils from \"@/utils/utils\";\n\ndescribe(\"Dev Stamp Index\", () => {\n  describe(stampInHtml, () => {\n    beforeEach(() => {\n      globalThis.window = window as unknown as typeof globalThis.window;\n      globalThis.document = document as unknown as Document;\n      window.document.body.innerHTML = \"<body><h1>Title</h1><p>Text</p></body>\";\n\n      vi.spyOn(CommentMode, \"stampCommentInHtml\").mockImplementation(vi.fn());\n      vi.spyOn(MetaTagMode, \"stampMetaTagInHtml\").mockImplementation(vi.fn());\n      vi.spyOn(Utils, \"getStampOptions\").mockReturnValue(DEFAULT_STAMP_OPTIONS);\n      vi.spyOn(Utils, \"validateBrowserEnvironment\").mockImplementation(vi.fn());\n    });\n\n    it(\"should validate the browser environment when called.\", () => {\n      const message = \"Hello Dark Jess' 🪄\";\n      stampInHtml(message, DEFAULT_STAMP_OPTIONS);\n\n      expect(Utils.validateBrowserEnvironment).toHaveBeenCalledExactlyOnceWith();\n    });\n\n    it(\"should call the comment mode when the mode is comment.\", () => {\n      const message = \"Hello Dark Jess' 🪄\";\n      const options: StampOptions = { ...DEFAULT_STAMP_OPTIONS, mode: \"comment\" };\n      stampInHtml(message, options);\n\n      expect(CommentMode.stampCommentInHtml).toHaveBeenCalledExactlyOnceWith(message, options);\n    });\n\n    it(\"should call the meta tag mode when the mode is meta-tag.\", () => {\n      const message = \"Hello Dark Jess' 🪄\";\n      const options: StampOptions = { ...DEFAULT_STAMP_OPTIONS, mode: \"meta-tag\" };\n      vi.spyOn(Utils, \"getStampOptions\").mockReturnValue(options);\n      stampInHtml(message, options);\n\n      expect(MetaTagMode.stampMetaTagInHtml).toHaveBeenCalledExactlyOnceWith(message, options);\n    });\n\n    it(\"should log an error when one of the stamp methods throws an error.\", () => {\n      const message = \"Hello Dark Jess' 🪄\";\n      const options: StampOptions = { ...DEFAULT_STAMP_OPTIONS, mode: \"comment\" };\n      const errorMessage = \"Test error\";\n      vi.spyOn(CommentMode, \"stampCommentInHtml\").mockImplementation(() => {\n        throw new Error(errorMessage);\n      });\n      const consoleErrorSpy = vi.spyOn(console, \"error\").mockImplementation(vi.fn());\n      stampInHtml(message, options);\n\n      expect(consoleErrorSpy).toHaveBeenCalledWith(new Error(errorMessage));\n    });\n  });\n});"
     },
     "src/utils/utils.spec.ts": {
       "tests": [
         {
+          "id": "4",
+          "name": "Dev Stamp Utils validateBrowserEnvironment should throw an error when not in a browser environment because window is undefined."
+        },
+        {
           "id": "5",
-          "name": "Dev Stamp Utils getStampOptions should return default options when no options are provided."
+          "name": "Dev Stamp Utils validateBrowserEnvironment should throw an error when not in a browser environment because document is undefined."
         },
         {
           "id": "6",
+          "name": "Dev Stamp Utils validateBrowserEnvironment should not throw an error when in a browser environment."
+        },
+        {
+          "id": "7",
+          "name": "Dev Stamp Utils getTargetElement should throw an error when the target element is not found."
+        },
+        {
+          "id": "8",
+          "name": "Dev Stamp Utils getTargetElement should return the target element when it is found."
+        },
+        {
+          "id": "9",
+          "name": "Dev Stamp Utils getStampOptions should return default options when no options are provided."
+        },
+        {
+          "id": "10",
           "name": "Dev Stamp Utils getStampOptions should override default options with provided options when called."
         }
       ],
-      "source": "import { describe } from \"vitest\";\n\nimport { DEFAULT_STAMP_OPTIONS } from \"@/index.constants\";\nimport { getStampOptions } from \"@/utils/utils\";\n\ndescribe(\"Dev Stamp Utils\", () => {\n  describe(getStampOptions, () => {\n    it(\"should return default options when no options are provided.\", () => {\n      const result = getStampOptions({});\n\n      expect(result).toStrictEqual(DEFAULT_STAMP_OPTIONS);\n    });\n\n    it(\"should override default options with provided options when called.\", () => {\n      const customOptions = { targetSelector: \"#custom\" };\n      const result = getStampOptions(customOptions);\n\n      expect(result).toStrictEqual({ ...DEFAULT_STAMP_OPTIONS, ...customOptions });\n    });\n  });\n});"
+      "source": "import { describe } from \"vitest\";\n\nimport type { PartialStampOptions, StampOptions } from \"@/index.types\";\nimport { DEFAULT_STAMP_OPTIONS } from \"@/index.constants\";\nimport { getStampOptions, getTargetElement, validateBrowserEnvironment } from \"@/utils/utils\";\n\ndescribe(\"Dev Stamp Utils\", () => {\n  describe(validateBrowserEnvironment, () => {\n    it(\"should throw an error when not in a browser environment because window is undefined.\", () => {\n      globalThis.window = undefined as unknown as typeof globalThis.window;\n\n      expect(() => validateBrowserEnvironment()).toThrow(\"This function can only be run in a browser environment.\");\n    });\n\n    it(\"should throw an error when not in a browser environment because document is undefined.\", () => {\n      globalThis.window = {} as unknown as typeof globalThis.window;\n\n      expect(() => validateBrowserEnvironment()).toThrow(\"This function can only be run in a browser environment.\");\n    });\n\n    it(\"should not throw an error when in a browser environment.\", () => {\n      globalThis.window = window as unknown as typeof globalThis.window;\n\n      expect(() => validateBrowserEnvironment()).not.toThrow();\n    });\n  });\n\n  describe(getTargetElement, () => {\n    it(\"should throw an error when the target element is not found.\", () => {\n      const targetSelector = \"#nonexistent\";\n\n      expect(() => getTargetElement(targetSelector)).toThrow(`Target element not found: ${targetSelector}`);\n    });\n\n    it(\"should return the target element when it is found.\", () => {\n      const targetSelector = \"h1\";\n      const targetElement = getTargetElement(targetSelector);\n\n      expect(targetElement.nodeName).toBe(\"H1\");\n    });\n  });\n\n  describe(getStampOptions, () => {\n    it(\"should return default options when no options are provided.\", () => {\n      const result = getStampOptions({});\n\n      expect(result).toStrictEqual<StampOptions>(DEFAULT_STAMP_OPTIONS);\n    });\n\n    it(\"should override default options with provided options when called.\", () => {\n      const customOptions: PartialStampOptions = {\n        targetSelector: \"#custom\",\n        metaTag: {},\n      };\n      const result = getStampOptions(customOptions);\n      const expectedOptions: StampOptions = {\n        ...DEFAULT_STAMP_OPTIONS,\n        ...customOptions,\n        metaTag: {\n          ...DEFAULT_STAMP_OPTIONS.metaTag,\n          ...customOptions.metaTag,\n        },\n      };\n\n      expect(result).toStrictEqual<StampOptions>(expectedOptions);\n    });\n  });\n});"
+    },
+    "src/modes/meta-tag/meta-tag.spec.ts": {
+      "tests": [
+        {
+          "id": "11",
+          "name": "Meta Tag Mode stampOnExistingMetaTag should set the content attribute of the existing meta tag to the message when overwrite is true."
+        },
+        {
+          "id": "12",
+          "name": "Meta Tag Mode stampOnExistingMetaTag should log an error when overwrite is false."
+        },
+        {
+          "id": "13",
+          "name": "Meta Tag Mode stampMetaTagInHtml should create a new meta tag with the message when there is no existing meta tag."
+        },
+        {
+          "id": "14",
+          "name": "Meta Tag Mode stampMetaTagInHtml should call stampOnExistingMetaTag when there is an existing meta tag."
+        }
+      ],
+      "source": "import { DEFAULT_STAMP_OPTIONS } from \"@/index.constants\";\nimport { stampMetaTagInHtml, stampOnExistingMetaTag } from \"@/modes/meta-tag/meta-tag\";\n\ndescribe(\"Meta Tag Mode\", () => {\n  describe(stampOnExistingMetaTag, () => {\n    it(\"should set the content attribute of the existing meta tag to the message when overwrite is true.\", () => {\n      const message = \"Hello Dark Jess' 🪄\";\n      const existingMetaTag = document.createElement(\"meta\");\n      const options = { name: \"description\", overwrite: true };\n      const setAttributeSpy = vi.spyOn(existingMetaTag, \"setAttribute\");\n      stampOnExistingMetaTag(message, existingMetaTag, options);\n\n      expect(setAttributeSpy).toHaveBeenCalledExactlyOnceWith(\"content\", message);\n    });\n\n    it(\"should log an error when overwrite is false.\", () => {\n      const message = \"Hello Dark Jess' 🪄\";\n      const existingMetaTag = document.createElement(\"meta\");\n      const options = { name: \"description\", overwrite: false };\n      const consoleErrorSpy = vi.spyOn(console, \"error\").mockImplementation(vi.fn());\n      stampOnExistingMetaTag(message, existingMetaTag, options);\n\n      expect(consoleErrorSpy).toHaveBeenCalledExactlyOnceWith(`Meta tag with name \"${options.name}\" already exists. Use \"overwrite\" option to replace it.`);\n    });\n  });\n\n  describe(stampMetaTagInHtml, () => {\n    it(\"should create a new meta tag with the message when there is no existing meta tag.\", () => {\n      const message = \"Hello Dark Jess' 🪄\";\n      const { head } = window.document;\n      const appendChildSpy = vi.spyOn(head, \"appendChild\");\n      const appendedMetaTag = window.document.createElement(\"meta\");\n      appendedMetaTag.setAttribute(\"name\", DEFAULT_STAMP_OPTIONS.metaTag.name);\n      appendedMetaTag.setAttribute(\"content\", message);\n      stampMetaTagInHtml(message, DEFAULT_STAMP_OPTIONS);\n\n      expect(appendChildSpy).toHaveBeenCalledExactlyOnceWith(appendedMetaTag);\n    });\n\n    it(\"should call stampOnExistingMetaTag when there is an existing meta tag.\", () => {\n      const message = \"Hello Dark Jess' 🪄\";\n      const { head } = window.document;\n      const existingMetaTag = window.document.createElement(\"meta\");\n      existingMetaTag.setAttribute(\"name\", DEFAULT_STAMP_OPTIONS.metaTag.name);\n      head.appendChild(existingMetaTag);\n      stampMetaTagInHtml(message, DEFAULT_STAMP_OPTIONS);\n\n      expect(existingMetaTag.getAttribute(\"content\")).toBe(message);\n    });\n  });\n});"
+    },
+    "src/modes/comment/comment.spec.ts": {
+      "tests": [
+        {
+          "id": "15",
+          "name": "Comment Mode stampCommentInHtml should get the target element when called."
+        },
+        {
+          "id": "16",
+          "name": "Comment Mode stampCommentInHtml should create comment node with the message when called."
+        }
+      ],
+      "source": "import { DEFAULT_STAMP_OPTIONS } from \"@/index.constants\";\nimport * as Utils from \"@/utils/utils\";\nimport { stampCommentInHtml } from \"@/modes/comment/comment\";\n\ndescribe(\"Comment Mode\", () => {\n  beforeEach(() => {\n    vi.spyOn(Utils, \"getTargetElement\").mockImplementation(() => document.createElement(\"body\"));\n  });\n\n  describe(stampCommentInHtml, () => {\n    it(\"should get the target element when called.\", () => {\n      const message = \"Hello Dark Jess' 🪄\";\n      stampCommentInHtml(message, DEFAULT_STAMP_OPTIONS);\n\n      expect(Utils.getTargetElement).toHaveBeenCalledWith(DEFAULT_STAMP_OPTIONS.targetSelector);\n    });\n\n    it(\"should create comment node with the message when called.\", () => {\n      const message = \"Hello Dark Jess' 🪄\";\n      const targetElement = window.document.querySelector(\"body\");\n      const commentNode = window.document.createComment(message);\n      const appendChildSpy = vi.spyOn(targetElement as Element, \"appendChild\");\n      vi.spyOn(Utils, \"getTargetElement\").mockReturnValue(targetElement as Element);\n      stampCommentInHtml(message, DEFAULT_STAMP_OPTIONS);\n\n      expect(appendChildSpy).toHaveBeenCalledWith(commentNode);\n    });\n  });\n});"
     }
   },
-  "projectRoot": "/Users/antoinezanardi/WebstormProjects/dev-stamp",
+  "projectRoot": "/Users/mac-Z14AZANA/WebstormProjects/dev-stamp",
   "config": {
     "cleanTempDir": "always",
     "incremental": true,

--- a/tests/unit/setup.ts
+++ b/tests/unit/setup.ts
@@ -1,0 +1,17 @@
+import { Window } from "happy-dom";
+
+const window = new Window({ url: "https://localhost:8080" });
+const { document } = window;
+
+beforeEach(() => {
+  globalThis.window = window as unknown as typeof globalThis.window;
+  globalThis.document = document as unknown as typeof globalThis.document;
+
+  window.document.body.innerHTML = `
+    <body>
+        <h1>Title</h1>
+        <p>Text</p>
+    </body>
+  `;
+  window.document.head.innerHTML = "";
+});

--- a/tests/unit/setup.ts
+++ b/tests/unit/setup.ts
@@ -8,10 +8,8 @@ beforeEach(() => {
   globalThis.document = document as unknown as typeof globalThis.document;
 
   window.document.body.innerHTML = `
-    <body>
-        <h1>Title</h1>
-        <p>Text</p>
-    </body>
+    <h1>Title</h1>
+    <p>Text</p>
   `;
   window.document.head.innerHTML = "";
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,6 +37,7 @@
     "eslint.config.ts",
     "release.config.mjs",
     "src/**/*",
-    "config/**/*"
+    "config/**/*",
+    "tests/**/*",
   ],
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for injecting a custom stamp into HTML as either a comment in the body or a meta tag in the head, with configurable options for each mode.

- **Bug Fixes**
  - Improved error handling for invalid browser environments and missing target elements.

- **Documentation**
  - Updated and expanded documentation to clearly describe the new injection modes and their configuration options.

- **Refactor**
  - Centralized environment validation and stamping logic for better modularity and maintainability.
  - Enhanced option merging with deep merge for nested meta tag settings.

- **Tests**
  - Added and updated tests to cover new features, error handling, and utility functions.
  - Introduced a new test setup for consistent DOM simulation in unit tests.

- **Chores**
  - Updated TypeScript and ESLint configurations to support new test files and modularized test rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->